### PR TITLE
Add TCP listener for logspout-logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 This image starts a logstash container with a basic configuration that parses:
  
+- JSON (e.g. for Logspout) in port 5000 (TCP and UDP)
 - syslog data in port 51415
 - gelf in port 12201/udp
 - beats in port 51044

--- a/rootfs/config-dir/01-inputs.conf
+++ b/rootfs/config-dir/01-inputs.conf
@@ -4,6 +4,10 @@ input {
     port  => 5000
     codec => "json"
   }
+  tcp {
+    port  => 5000
+    codec => "json"
+  }
 
   # Listens on 514/udp and 514/tcp by default; change that to non-privileged port
   syslog {


### PR DESCRIPTION
This allows the option of a reliable delivery of logspout events using
e.g. a `logstash+tcp://logstash:5000` route in logspout.